### PR TITLE
Fix case-sensitive import and style typo

### DIFF
--- a/src/Bio.jsx
+++ b/src/Bio.jsx
@@ -43,7 +43,7 @@ export const Bio = () => {
       
       {/* Skills section */}
       <div className="skills-section mt-4 mb-3">
-        <h3 style={{ fontFamily: 'RedHatDisplay-Bold', olor: '#343434' }}>Skills</h3>
+        <h3 style={{ fontFamily: 'RedHatDisplay-Bold', color: '#343434' }}>Skills</h3>
         <div className="skills-container">
           {skills.map((skill, index) => (
             <span key={index} className="skill-badge">{skill}</span>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Home from './Home'
+import Home from './home'
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './Enhanced.css';


### PR DESCRIPTION
## Summary
- fix import path case for Home component
- correct color style typo in Bio

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6883a837b7f88326ba4ffd9b6dc10e53